### PR TITLE
implement Dry.Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,25 @@ Dry tries to provide a nice DSL for building complex data structures, without ha
 defmodule Sibling do
   use Dry
 
+  alias Dry.Types
+
   schema do
-    attribute(:name, :string)
+    attribute(:name, Types.String)
   end
 end
 
 defmodule User do
   use Dry
 
+  alias Dry.Types
+
   schema do
-    attribute(:name, :string)
-    attribute(:age, :integer, optional: true)
+    attribute(:name, Types.String)
+    attribute(:age, Types.Integer.options(optional: true))
     attribute(:height)
-    attribute(:country, :string, default: "UK")
-    attribute(:siblings, array_of: Sibling)
-    attribute(:favourite_colours, array_of: :string, default: ["blue", "green"])
+    attribute(:country, Types.String.options(default: "UK"))
+    attribute(:siblings, Types.Array.options(type: Sibling))
+    attribute(:favourite_colours, Types.Array.options(type: Types.String, default: ["blue", "green"]))
 
     attribute :is_adult do
       Map.get(entity, :age, 0) >= 18
@@ -45,7 +49,7 @@ user == %User{
   siblings: [%Sibling{name: "John"}],
   favourite_colours: ["blue", "green"]
 }
-{:ok, _user} = User.new(%{name: "Rob", age: 18, height: 169, country: "BG", siblings: [%{name: "John"}]})
+{:ok, _user} = User.new(%{name: "Rob", age: 18, height: 169, country: "BG", siblings: [%{name: "John"}]})  ```
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ by adding `dry` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:dry,  0.1.0"}
+    {:dry,  0.1.1"}
   ]
 end
 ```

--- a/lib/dry.ex
+++ b/lib/dry.ex
@@ -70,6 +70,7 @@ defmodule Dry do
       quote unquote: false do
         @attributes
         |> Enum.map(fn attr -> Enum.at(attr, 0) end)
+        |> Enum.concat([__dry__: true])
         |> Kernel.defstruct()
 
         def __attributes__(), do: @attributes

--- a/lib/dry.ex
+++ b/lib/dry.ex
@@ -5,22 +5,24 @@ defmodule Dry do
   ```elixir
   defmodule Sibling do
     use Dry
+    alias Dry.Types
 
     schema do
-      attribute(:name, :string)
+      attribute(:name, Types.String)
     end
   end
 
   defmodule User do
     use Dry
+    alias Dry.Types
 
     schema do
-        attribute(:name, :string)
-        attribute(:age, :integer, optional: true)
+        attribute(:name, Types.String)
+        attribute(:age, Types.Integer.options(optional: true))
         attribute(:height)
-        attribute(:country, :string, default: "UK")
-        attribute(:siblings, array_of: Sibling)
-        attribute(:favourite_colours, array_of: :string, default: ["blue", "green"])
+        attribute(:country, Types.String.options(default: "UK"))
+        attribute(:siblings, Types.Array.options(type: Sibling))
+        attribute(:favourite_colours, Types.Array.options(type: Types.String, default: ["blue", "green"]))
 
         attribute :is_adult do
           Map.get(entity, :age, 0) >= 18
@@ -70,7 +72,6 @@ defmodule Dry do
       quote unquote: false do
         @attributes
         |> Enum.map(fn attr -> Enum.at(attr, 0) end)
-        |> Enum.concat([__dry__: true])
         |> Kernel.defstruct()
 
         def __attributes__(), do: @attributes
@@ -101,6 +102,9 @@ defmodule Dry do
           end
         end
 
+        def valid?(%{__struct__: __MODULE__} = value) when is_struct(value), do: true
+        def valid?(_value), do: false
+
         @doc "Used to recognise Dry modules"
         def __dry__(), do: true
       end
@@ -109,11 +113,11 @@ defmodule Dry do
       unquote(prelude)
       unquote(postlude)
     end
-  end
+   end
 
   defmacro attribute(name) do
     quote do
-      attribute(unquote(name), nil, [])
+      attribute(unquote(name), nil)
     end
   end
 
@@ -130,21 +134,9 @@ defmodule Dry do
     end
   end
 
-  defmacro attribute(name, opts) when is_list(opts) do
-    quote do
-      attribute(unquote(name), nil, unquote(opts))
-    end
-  end
-
   defmacro attribute(name, type) do
     quote do
-      attribute(unquote(name), unquote(type), [])
-    end
-  end
-
-  defmacro attribute(name, [] = type, _opts) do
-    quote do
-      attribute(unquote(name), nil, unquote(type))
+      Module.put_attribute(__MODULE__, :attributes, [unquote(name), unquote(type)])
     end
   end
 

--- a/lib/dry.ex
+++ b/lib/dry.ex
@@ -113,7 +113,7 @@ defmodule Dry do
       unquote(prelude)
       unquote(postlude)
     end
-   end
+  end
 
   defmacro attribute(name) do
     quote do

--- a/lib/processor.ex
+++ b/lib/processor.ex
@@ -32,8 +32,10 @@ defmodule Dry.Processor do
     case Types.Array.valid_list?(type, converted) do
       true ->
         {name, converted}
+
       false ->
         invalid(name, type, value, module)
+
       {:error, problem_value} ->
         invalid(name, type, problem_value, module)
     end
@@ -61,9 +63,13 @@ defmodule Dry.Processor do
     case type.new(value) do
       {:ok, value} ->
         {name, value}
+
       {:error, message} ->
         raise Dry.RuntimeError,
-          message: "[#{inspect(module)}] - An error occured when trying to initialize #{inspect(type)} with #{inspect(value)} for #{inspect(name)}. Original error: #{message}"
+          message:
+            "[#{inspect(module)}] - An error occured when trying to initialize #{inspect(type)} with #{
+              inspect(value)
+            } for #{inspect(name)}. Original error: #{message}"
     end
   end
 

--- a/lib/processor.ex
+++ b/lib/processor.ex
@@ -1,102 +1,78 @@
 defmodule Dry.Processor do
   @moduledoc false
 
+  alias Dry.Types
+
   def process([name, :__func__], attr, module) do
     {name, apply(module, name, [attr])}
   end
 
-  def process([name, type, opts], attr, module) do
-    default = Keyword.get(opts, :default, :__dry_undefined__)
-    array = Keyword.get(opts, :array_of, nil)
-    optional = Keyword.get(opts, :optional, false)
+  def process([name, type], attr, module) do
     value = Map.get(attr, name)
 
-    if array do
-      process(name, [array_of: array], value, default, optional, module)
-    else
-      process(name, type, value, default, optional, module)
-    end
+    process(name, type, value, module)
   end
 
-  def process(name, _type, _value = nil, _default = :__dry_undefined__, _optional = false, module) do
+  def process(name, %{default: default} = type, nil = _value, _module) when is_struct(type) do
+    {name, default}
+  end
+
+  def process(name, %{optional: true} = type, nil = _value, _module) when is_struct(type) do
+    {name, nil}
+  end
+
+  def process(name, _type, _value = nil, module) do
     raise Dry.RuntimeError,
       message: "[#{inspect(module)}] - Required attribute :#{name} is missing"
   end
 
-  def process(name, _type, value = nil, _default = :__dry_undefined__, _optional = true, _module) do
-    {name, value}
-  end
+  def process(name, %Types.Array{type: type}, value, module) do
+    converted = convert_list(name, type, value, module)
 
-  def process(name, _type, _value = nil, default, _optional, _module) do
-    {name, default}
-  end
-
-  def process(name, _type = nil, value, _default, _optional, _module) do
-    {name, value}
-  end
-
-  def process(name, [array_of: type], value, default, optional, module) when is_list(value) do
-    {name,
-     Enum.map(value, fn x ->
-       {_name, value} = process(name, type, x, default, optional, module)
-       value
-     end)}
-  end
-
-  def process(name, :string, value, _default, _optional, _module) when is_binary(value) do
-    {name, value}
-  end
-
-  def process(name, :integer, value, _default, _optional, _module) when is_integer(value) do
-    {name, value}
-  end
-
-  def process(name, :float, value, _default, _optional, _module) when is_float(value) do
-    {name, value}
-  end
-
-  def process(name, :atom, value, _default, _optional, _module) when is_atom(value) do
-    {name, value}
-  end
-
-  def process(name, :bool, value, _default, _optional, _module) when is_boolean(value) do
-    {name, value}
-  end
-
-  def process(name, :map, value, _default, _optional, _module) when is_map(value) do
-    {name, value}
-  end
-
-  def process(name, type, value, _default, _optional, module) when is_map(value) do
-    if Kernel.function_exported?(type, :__dry__, 0) do
-      try do
-        {name, type.new!(value)}
-      rescue
-        e in Dry.RuntimeError ->
-          reraise Dry.RuntimeError,
-                  [
-                    message:
-                      "[#{inspect(module)}] - Failed to initialise #{inspect(type)} with #{
-                        inspect(value)
-                      } for #{inspect(name)}. Original error - #{e.message}"
-                  ],
-                  __STACKTRACE__
-      end
-    else
-      invalid(name, type, value, module)
+    case Types.Array.valid_list?(type, converted) do
+      true ->
+        {name, converted}
+      false ->
+        invalid(name, type, value, module)
+      {:error, problem_value} ->
+        invalid(name, type, problem_value, module)
     end
   end
 
-  def process(name, type, value, _default, _optional, module) when is_struct(value) do
-    if value.__struct__ == type do
-      {name, value}
-    else
-      invalid(name, type, value, module)
+  def process(name, %{__struct__: type} = struct, value, module) when is_struct(struct) do
+    Code.ensure_loaded(type)
+    functions = type.__info__(:functions) |> Enum.into(%{})
+
+    process_advanced(name, type, functions, value, module)
+  end
+
+  def process(name, _type = nil, value, _module) do
+    {name, value}
+  end
+
+  def process(name, type, value, module) do
+    Code.ensure_loaded(type)
+    functions = type.__info__(:functions) |> Enum.into(%{})
+
+    process_advanced(name, type, functions, value, module)
+  end
+
+  def process_advanced(name, type, %{__dry__: 0, valid?: 1}, value, module) when is_map(value) do
+    case type.new(value) do
+      {:ok, value} ->
+        {name, value}
+      {:error, message} ->
+        raise Dry.RuntimeError,
+          message: "[#{inspect(module)}] - An error occured when trying to initialize #{inspect(type)} with #{inspect(value)} for #{inspect(name)}. Original error: #{message}"
     end
   end
 
-  def process(name, type, value, _default, _optional, module) do
-    invalid(name, type, value, module)
+  def process_advanced(name, type, %{valid?: 1}, value, module) do
+    if type.valid?(value), do: {name, value}, else: invalid(name, type, value, module)
+  end
+
+  def function?(attribute) do
+    Enum.at(attribute, 1, nil) == :__func__
   end
 
   defp invalid(name, type, value, module) do
@@ -107,7 +83,15 @@ defmodule Dry.Processor do
         }"
   end
 
-  def function?(attribute) do
-    Enum.at(attribute, 1, nil) == :__func__
+  defp convert_list(name, type, list, module) when is_list(list) do
+    Code.ensure_loaded(type)
+    functions = type.__info__(:functions) |> Enum.into(%{})
+
+    Enum.map(list, fn item ->
+      {_name, converted} = process_advanced(name, type, functions, item, module)
+      converted
+    end)
   end
+
+  defp convert_list(_name, _type, list, _module), do: list
 end

--- a/lib/types/array.ex
+++ b/lib/types/array.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Array do
+  @moduledoc """
+    Represents the array type
+  """
+
+  defstruct [:of, :default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/array.ex
+++ b/lib/types/array.ex
@@ -3,9 +3,23 @@ defmodule Dry.Types.Array do
     Represents the array type
   """
 
-  defstruct [:of, :default, :optional]
+  defstruct [:type, :default, :optional]
 
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid_list?(type, [head | tail]) do
+    if Kernel.function_exported?(type, :valid?, 1) do
+      if type.valid?(head), do: valid_list?(type, tail), else: {:error, head}
+    else
+      false
+    end
+  end
+
+  def valid_list?(_type, []), do: true
+  def valid_list?(_type, _value), do: false
+
+  def valid?(value) when is_list(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/array.ex
+++ b/lib/types/array.ex
@@ -1,10 +1,20 @@
 defmodule Dry.Types.Array do
   @moduledoc """
-    Represents the array type
+  Represents the array type
+
+  ## Examples:
+  ```elixir
+  schema do
+    attribute :favourite_numbers, Types.Array.options(type: Types.Integer, default: [1,2,3])
+    attribute :any, Types.Array.options(default: [1,2,3])
+    attribute :cars, Types.Array.options(type: Types.String, optional: true)
+  end
+  ```
   """
 
   defstruct [:type, :default, :optional]
 
+  @doc "Valid options are :type, :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/atom.ex
+++ b/lib/types/atom.ex
@@ -1,10 +1,20 @@
 defmodule Dry.Types.Atom do
   @moduledoc """
-    Represents the atom type
+  Represents the atom type
+
+  ## Examples:
+  ```elixir
+  schema do
+    attribute :field_1, Types.Atom
+    attribute :field_2, Types.Atom.options(optional: true)
+    attribute :field_3, Types.Atom.options(default: :atom)
+  end
+  ```
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/atom.ex
+++ b/lib/types/atom.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.Atom do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_atom(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/atom.ex
+++ b/lib/types/atom.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Atom do
+  @moduledoc """
+    Represents the atom type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/bool.ex
+++ b/lib/types/bool.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Bool do
+  @moduledoc """
+    Represents the bool type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/bool.ex
+++ b/lib/types/bool.ex
@@ -1,10 +1,19 @@
 defmodule Dry.Types.Bool do
   @moduledoc """
-    Represents the bool type
+  Represents the bool type
+
+  ## Examples:
+  ```elixir
+  schema do
+    ttribute :field_1, Types.Bool
+    attribute :field_2, Types.Bool.options(optional: true)
+    attribute :field_3, Types.Bool.options(default: false)
+  end
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/bool.ex
+++ b/lib/types/bool.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.Bool do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_boolean(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/float.ex
+++ b/lib/types/float.ex
@@ -1,10 +1,19 @@
 defmodule Dry.Types.Float do
   @moduledoc """
-    Represents the float type
+  Represents the float type
+
+  ## Examples:
+  ```elixir
+  schema do
+    ttribute :field_1, Types.Float
+    attribute :field_2, Types.Float.options(optional: true)
+    attribute :field_3, Types.Float.options(default: 15.5)
+  end
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/float.ex
+++ b/lib/types/float.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.Float do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_float(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/float.ex
+++ b/lib/types/float.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Float do
+  @moduledoc """
+    Represents the float type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/integer.ex
+++ b/lib/types/integer.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.Integer do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_integer(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/integer.ex
+++ b/lib/types/integer.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Integer do
+  @moduledoc """
+    Represents the integer type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/integer.ex
+++ b/lib/types/integer.ex
@@ -1,10 +1,19 @@
 defmodule Dry.Types.Integer do
   @moduledoc """
-    Represents the integer type
+  Represents the integer type
+
+  ## Examples:
+  ```elixir
+  schema do
+    ttribute :field_1, Types.Integer
+    attribute :field_2, Types.Integer.options(optional: true)
+    attribute :field_3, Types.Integer.options(default: 10)
+  end
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/map.ex
+++ b/lib/types/map.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.Map do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_map(value), do: true
+  def valid?(_value), do: false
 end

--- a/lib/types/map.ex
+++ b/lib/types/map.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.Map do
+  @moduledoc """
+    Represents the map type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/map.ex
+++ b/lib/types/map.ex
@@ -1,10 +1,19 @@
 defmodule Dry.Types.Map do
   @moduledoc """
-    Represents the map type
+  Represents the map type
+
+  ## Examples:
+  ```elixir
+  schema do
+    ttribute :field_1, Types.Map
+    attribute :field_2, Types.Map.options(optional: true)
+    attribute :field_3, Types.Map.options(default: %{hello: :world})
+  end
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/string.ex
+++ b/lib/types/string.ex
@@ -1,10 +1,19 @@
 defmodule Dry.Types.String do
   @moduledoc """
-    Represents the string type
+  Represents the string type
+
+  ## Examples:
+  ```elixir
+  schema do
+    ttribute :field_1, Types.String
+    attribute :field_2, Types.String.options(optional: true)
+    attribute :field_3, Types.String.options(default: "default text")
+  end
   """
 
   defstruct [:default, :optional]
 
+  @doc "Valid options are :default and :optional"
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end

--- a/lib/types/string.ex
+++ b/lib/types/string.ex
@@ -1,0 +1,11 @@
+defmodule Dry.Types.String do
+  @moduledoc """
+    Represents the string type
+  """
+
+  defstruct [:default, :optional]
+
+  def options(opts \\ []) do
+    struct(__MODULE__, opts)
+  end
+end

--- a/lib/types/string.ex
+++ b/lib/types/string.ex
@@ -8,4 +8,7 @@ defmodule Dry.Types.String do
   def options(opts \\ []) do
     struct(__MODULE__, opts)
   end
+
+  def valid?(value) when is_binary(value), do: true
+  def valid?(_value), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dry.MixProject do
   def project do
     [
       app: :dry,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/dry_test.exs
+++ b/test/dry_test.exs
@@ -13,14 +13,15 @@ defmodule DryTest do
 
   defmodule Test do
     use Dry
+    alias Dry.Types
 
     schema do
-      attribute(:name, :string)
-      attribute(:age, :integer, optional: true)
-      attribute(:height, default: 190)
-      attribute(:country, :string, default: "UK")
-      attribute(:siblings, array_of: :string, default: ["Bob", "Mark"])
-      attribute(:parents, array_of: Parent, optional: true)
+      attribute(:name, Types.String)
+      attribute(:age, Types.Integer.options(optional: true))
+      attribute(:height, Types.Integer.options(default: 190))
+      attribute(:country, Types.String.options(default: "UK"))
+      attribute(:siblings, Types.Array.options(type: Types.String, default: ["Bob", "Mark"]))
+      attribute(:parents, Types.Array.options(type: Parent, optional: true))
 
       attribute :is_adult do
         (entity.age || 0) >= 18
@@ -78,13 +79,13 @@ defmodule DryTest do
     context "when a list attribute has the wrong type" do
       it "raises an exception" do
         assert_raise Dry.RuntimeError,
-                     "[DryTest.Test] - `1` has invalid type for :siblings. Expected type is :string",
+                     "[DryTest.Test] - `1` has invalid type for :siblings. Expected type is Dry.Types.String",
                      fn ->
                        Test.new!(%{name: "Bob", age: 5, siblings: ["bob", 1]})
                      end
 
         assert_raise Dry.RuntimeError,
-                     "[DryTest.Test] - `\"Bob\"` has invalid type for :parents. Expected type is [array_of: DryTest.Parent]",
+                     "[DryTest.Test] - `\"Bob\"` has invalid type for :parents. Expected type is DryTest.Parent",
                      fn ->
                        Test.new!(%{name: "Bob", age: 5, parents: "Bob"})
                      end
@@ -96,7 +97,7 @@ defmodule DryTest do
                      end
 
         assert_raise Dry.RuntimeError,
-                     "[DryTest.Test] - `1` has invalid type for :siblings. Expected type is [array_of: :string]",
+                     "[DryTest.Test] - `1` has invalid type for :siblings. Expected type is Dry.Types.String",
                      fn ->
                        Test.new!(%{name: "Bob", age: 5, siblings: 1})
                      end

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -3,51 +3,52 @@ defmodule Dry.ProcessorTest do
 
   import Dry.Processor
   alias Dry.ExampleStruct
+  alias Dry.Types
 
   @test_types [
     %{
-      type: :string,
+      type: Types.String,
       value: "bob",
       invalid_value: 5,
-      error: "[Dry.RuntimeError] - `5` has invalid type for :name. Expected type is :string"
+      error: "[Test] - `5` has invalid type for :name. Expected type is Dry.Types.String"
     },
     %{
-      type: :integer,
+      type: Types.Integer,
       value: 5,
       invalid_value: 5.5,
-      error: "[Dry.RuntimeError] - `5.5` has invalid type for :name. Expected type is :integer"
+      error: "[Test] - `5.5` has invalid type for :name. Expected type is Dry.Types.Integer"
     },
     %{
-      type: :float,
+      type: Types.Float,
       value: 10.5,
       invalid_value: "bob",
-      error: "[Dry.RuntimeError] - `\"bob\"` has invalid type for :name. Expected type is :float"
+      error: "[Test] - `\"bob\"` has invalid type for :name. Expected type is Dry.Types.Float"
     },
     %{
-      type: :bool,
+      type: Types.Bool,
       value: true,
       invalid_value: %{age: 15},
       error:
-        "[Dry.RuntimeError] - `%{age: 15}` has invalid type for :name. Expected type is :bool"
+        "[Test] - `%{age: 15}` has invalid type for :name. Expected type is Dry.Types.Bool"
     },
     %{
-      type: :atom,
+      type: Types.Atom,
       value: :dog,
       invalid_value: 100,
-      error: "[Dry.RuntimeError] - `100` has invalid type for :name. Expected type is :atom"
+      error: "[Test] - `100` has invalid type for :name. Expected type is Dry.Types.Atom"
     },
     %{
-      type: :map,
+      type: Types.Map,
       value: %{name: "Bob"},
       invalid_value: 100,
-      error: "[Dry.RuntimeError] - `100` has invalid type for :name. Expected type is :map"
+      error: "[Test] - `100` has invalid type for :name. Expected type is Dry.Types.Map"
     },
     %{
       type: ExampleStruct,
       value: %ExampleStruct{name: "Bob"},
       invalid_value: 5,
       error:
-        "[Dry.RuntimeError] - `5` has invalid type for :name. Expected type is Dry.ExampleStruct"
+        "[Test] - `5` has invalid type for :name. Expected type is Dry.ExampleStruct"
     },
     %{
       type: ExampleStruct,
@@ -55,7 +56,15 @@ defmodule Dry.ProcessorTest do
       expected_value: %ExampleStruct{name: "Bob"},
       invalid_value: %{name: 1},
       error:
-        "[Dry.RuntimeError] - Failed to initialise Dry.ExampleStruct with %{name: 1} for :name. Original error - [Dry.ExampleStruct] - `1` has invalid type for :name. Expected type is :string"
+        "[Test] - An error occured when trying to initialize Dry.ExampleStruct with %{name: 1} for :name. Original error: [Dry.ExampleStruct] - `1` has invalid type for :name. Expected type is Dry.Types.String"
+    },
+    %{
+      type: Types.Array.options(type: ExampleStruct),
+      value: [%{name: "Bob"}],
+      expected_value: [%ExampleStruct{name: "Bob"}],
+      invalid_value: [%{name: 1}],
+      error:
+        "[Test] - An error occured when trying to initialize Dry.ExampleStruct with %{name: 1} for :name. Original error: [Dry.ExampleStruct] - `1` has invalid type for :name. Expected type is Dry.Types.String"
     }
   ]
 
@@ -63,11 +72,11 @@ defmodule Dry.ProcessorTest do
     context "types" do
       it "works as expected" do
         Enum.each(@test_types, fn test ->
-          assert process(:name, test.type, test.value, nil, nil, nil) ==
+          assert process(:name, test.type, test.value, Test) ==
                    {:name, Map.get(test, :expected_value, test.value)}
 
           assert_raise Dry.RuntimeError, test.error, fn ->
-            process(:name, test.type, test.invalid_value, nil, nil, Dry.RuntimeError)
+            process(:name, test.type, test.invalid_value, Test)
           end
         end)
       end

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -28,8 +28,7 @@ defmodule Dry.ProcessorTest do
       type: Types.Bool,
       value: true,
       invalid_value: %{age: 15},
-      error:
-        "[Test] - `%{age: 15}` has invalid type for :name. Expected type is Dry.Types.Bool"
+      error: "[Test] - `%{age: 15}` has invalid type for :name. Expected type is Dry.Types.Bool"
     },
     %{
       type: Types.Atom,
@@ -47,8 +46,7 @@ defmodule Dry.ProcessorTest do
       type: ExampleStruct,
       value: %ExampleStruct{name: "Bob"},
       invalid_value: 5,
-      error:
-        "[Test] - `5` has invalid type for :name. Expected type is Dry.ExampleStruct"
+      error: "[Test] - `5` has invalid type for :name. Expected type is Dry.ExampleStruct"
     },
     %{
       type: ExampleStruct,

--- a/test/support/example_struct.ex
+++ b/test/support/example_struct.ex
@@ -4,6 +4,6 @@ defmodule Dry.ExampleStruct do
   use Dry
 
   schema do
-    attribute(:name, :string)
+    attribute(:name, Dry.Types.String)
   end
 end

--- a/test/types/array_test.exs
+++ b/test/types/array_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.ArrayTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Array.options(default: :array, optional: true) == %Types.Array{optional: true, default: :array}
+      assert Types.Array.options(default: :array, optional: true) == %Types.Array{
+               optional: true,
+               default: :array
+             }
+
       assert Types.Array.options(default: :array) == %Types.Array{default: :array}
       assert Types.Array.options(type: Types.Array) == %Types.Array{type: Types.Array}
       assert Types.Array.options(invalid: :array) == %Types.Array{}

--- a/test/types/array_test.exs
+++ b/test/types/array_test.exs
@@ -1,0 +1,15 @@
+defmodule Dry.Types.ArrayTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Array.options(default: :array, optional: true) == %Types.Array{optional: true, default: :array}
+      assert Types.Array.options(default: :array) == %Types.Array{default: :array}
+      assert Types.Array.options(of: Types.String) == %Types.Array{of: Types.String}
+      assert Types.Array.options(invalid: :array) == %Types.Array{}
+      assert Types.Array.options() == %Types.Array{}
+    end
+  end
+end

--- a/test/types/array_test.exs
+++ b/test/types/array_test.exs
@@ -7,9 +7,44 @@ defmodule Dry.Types.ArrayTest do
     it "returns the correct struct" do
       assert Types.Array.options(default: :array, optional: true) == %Types.Array{optional: true, default: :array}
       assert Types.Array.options(default: :array) == %Types.Array{default: :array}
-      assert Types.Array.options(of: Types.String) == %Types.Array{of: Types.String}
+      assert Types.Array.options(type: Types.Array) == %Types.Array{type: Types.Array}
       assert Types.Array.options(invalid: :array) == %Types.Array{}
       assert Types.Array.options() == %Types.Array{}
+    end
+  end
+
+  describe "#valid?" do
+    context "when value is array" do
+      it "returns true" do
+        assert Types.Array.valid?([]) == true
+        assert Types.Array.valid?([1, "a", 5.5]) == true
+      end
+    end
+
+    context "when value is not a array" do
+      it "returns false" do
+        assert Types.Array.valid?(5) == false
+      end
+    end
+  end
+
+  describe "#valid_list?" do
+    context "when all elements in a list are valid" do
+      it "returns true" do
+        assert Types.Array.valid_list?(Types.String, ["bob", "mark"]) == true
+      end
+    end
+
+    context "when one of the elements in a list is invalid" do
+      it "returns the correct error" do
+        assert Types.Array.valid_list?(Types.String, ["bob", 1, "mark"]) == {:error, 1}
+      end
+    end
+
+    context "when the value is not an array" do
+      it "returns false" do
+        assert Types.Array.valid_list?(Types.String, "string") == false
+      end
     end
   end
 end

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.AtomTest do
       assert Types.Atom.options() == %Types.Atom{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is atom" do
+      it "returns true" do
+        assert Types.Atom.valid?(:bob) == true
+      end
+    end
+
+    context "when value is not an atom" do
+      it "returns false" do
+        assert Types.Atom.valid?(5) == false
+      end
+    end
+  end
 end

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.AtomTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Atom.options(default: :atom, optional: true) == %Types.Atom{optional: true, default: :atom}
+      assert Types.Atom.options(default: :atom) == %Types.Atom{default: :atom}
+      assert Types.Atom.options(invalid: :atom) == %Types.Atom{}
+      assert Types.Atom.options() == %Types.Atom{}
+    end
+  end
+end

--- a/test/types/atom_test.exs
+++ b/test/types/atom_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.AtomTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Atom.options(default: :atom, optional: true) == %Types.Atom{optional: true, default: :atom}
+      assert Types.Atom.options(default: :atom, optional: true) == %Types.Atom{
+               optional: true,
+               default: :atom
+             }
+
       assert Types.Atom.options(default: :atom) == %Types.Atom{default: :atom}
       assert Types.Atom.options(invalid: :atom) == %Types.Atom{}
       assert Types.Atom.options() == %Types.Atom{}

--- a/test/types/bool_test.exs
+++ b/test/types/bool_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.BoolTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Bool.options(default: true, optional: true) == %Types.Bool{optional: true, default: true}
+      assert Types.Bool.options(default: true) == %Types.Bool{default: true}
+      assert Types.Bool.options(invalid: true) == %Types.Bool{}
+      assert Types.Bool.options() == %Types.Bool{}
+    end
+  end
+end

--- a/test/types/bool_test.exs
+++ b/test/types/bool_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.BoolTest do
       assert Types.Bool.options() == %Types.Bool{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is bool" do
+      it "returns true" do
+        assert Types.Bool.valid?(false) == true
+      end
+    end
+
+    context "when value is not a bool" do
+      it "returns false" do
+        assert Types.Bool.valid?(5) == false
+      end
+    end
+  end
 end

--- a/test/types/bool_test.exs
+++ b/test/types/bool_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.BoolTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Bool.options(default: true, optional: true) == %Types.Bool{optional: true, default: true}
+      assert Types.Bool.options(default: true, optional: true) == %Types.Bool{
+               optional: true,
+               default: true
+             }
+
       assert Types.Bool.options(default: true) == %Types.Bool{default: true}
       assert Types.Bool.options(invalid: true) == %Types.Bool{}
       assert Types.Bool.options() == %Types.Bool{}

--- a/test/types/float_test.exs
+++ b/test/types/float_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.FloatTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Float.options(default: 15.5, optional: true) == %Types.Float{optional: true, default: 15.5}
+      assert Types.Float.options(default: 15.5, optional: true) == %Types.Float{
+               optional: true,
+               default: 15.5
+             }
+
       assert Types.Float.options(default: 15.5) == %Types.Float{default: 15.5}
       assert Types.Float.options(invalid: 15.5) == %Types.Float{}
       assert Types.Float.options() == %Types.Float{}

--- a/test/types/float_test.exs
+++ b/test/types/float_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.FloatTest do
       assert Types.Float.options() == %Types.Float{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is float" do
+      it "returns true" do
+        assert Types.Float.valid?(5.5) == true
+      end
+    end
+
+    context "when value is not a float" do
+      it "returns false" do
+        assert Types.Float.valid?(5) == false
+      end
+    end
+  end
 end

--- a/test/types/float_test.exs
+++ b/test/types/float_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.FloatTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Float.options(default: 15.5, optional: true) == %Types.Float{optional: true, default: 15.5}
+      assert Types.Float.options(default: 15.5) == %Types.Float{default: 15.5}
+      assert Types.Float.options(invalid: 15.5) == %Types.Float{}
+      assert Types.Float.options() == %Types.Float{}
+    end
+  end
+end

--- a/test/types/integer_test.exs
+++ b/test/types/integer_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.IntegerTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Integer.options(default: 10, optional: true) == %Types.Integer{optional: true, default: 10}
+      assert Types.Integer.options(default: 10) == %Types.Integer{default: 10}
+      assert Types.Integer.options(invalid: 10) == %Types.Integer{}
+      assert Types.Integer.options() == %Types.Integer{}
+    end
+  end
+end

--- a/test/types/integer_test.exs
+++ b/test/types/integer_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.IntegerTest do
       assert Types.Integer.options() == %Types.Integer{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is integer" do
+      it "returns true" do
+        assert Types.Integer.valid?(5) == true
+      end
+    end
+
+    context "when value is not an integer" do
+      it "returns false" do
+        assert Types.Integer.valid?("bob") == false
+      end
+    end
+  end
 end

--- a/test/types/integer_test.exs
+++ b/test/types/integer_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.IntegerTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Integer.options(default: 10, optional: true) == %Types.Integer{optional: true, default: 10}
+      assert Types.Integer.options(default: 10, optional: true) == %Types.Integer{
+               optional: true,
+               default: 10
+             }
+
       assert Types.Integer.options(default: 10) == %Types.Integer{default: 10}
       assert Types.Integer.options(invalid: 10) == %Types.Integer{}
       assert Types.Integer.options() == %Types.Integer{}

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.MapTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.Map.options(default: %{a: 1}, optional: true) == %Types.Map{optional: true, default: %{a: 1}}
+      assert Types.Map.options(default: %{a: 1}) == %Types.Map{default: %{a: 1}}
+      assert Types.Map.options(invalid: %{a: 1}) == %Types.Map{}
+      assert Types.Map.options() == %Types.Map{}
+    end
+  end
+end

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.MapTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.Map.options(default: %{a: 1}, optional: true) == %Types.Map{optional: true, default: %{a: 1}}
+      assert Types.Map.options(default: %{a: 1}, optional: true) == %Types.Map{
+               optional: true,
+               default: %{a: 1}
+             }
+
       assert Types.Map.options(default: %{a: 1}) == %Types.Map{default: %{a: 1}}
       assert Types.Map.options(invalid: %{a: 1}) == %Types.Map{}
       assert Types.Map.options() == %Types.Map{}

--- a/test/types/map_test.exs
+++ b/test/types/map_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.MapTest do
       assert Types.Map.options() == %Types.Map{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is map" do
+      it "returns true" do
+        assert Types.Map.valid?(%{key: true}) == true
+      end
+    end
+
+    context "when value is not a map" do
+      it "returns false" do
+        assert Types.Map.valid?(5) == false
+      end
+    end
+  end
 end

--- a/test/types/string_test.exs
+++ b/test/types/string_test.exs
@@ -5,7 +5,11 @@ defmodule Dry.Types.StringTest do
 
   describe "#options" do
     it "returns the correct struct" do
-      assert Types.String.options(default: "str", optional: true) == %Types.String{optional: true, default: "str"}
+      assert Types.String.options(default: "str", optional: true) == %Types.String{
+               optional: true,
+               default: "str"
+             }
+
       assert Types.String.options(default: "str") == %Types.String{default: "str"}
       assert Types.String.options(invalid: "str") == %Types.String{}
       assert Types.String.options() == %Types.String{}

--- a/test/types/string_test.exs
+++ b/test/types/string_test.exs
@@ -11,4 +11,18 @@ defmodule Dry.Types.StringTest do
       assert Types.String.options() == %Types.String{}
     end
   end
+
+  describe "#valid?" do
+    context "when value is string" do
+      it "returns true" do
+        assert Types.String.valid?("bob") == true
+      end
+    end
+
+    context "when value is not a string" do
+      it "returns false" do
+        assert Types.String.valid?(5) == false
+      end
+    end
+  end
 end

--- a/test/types/string_test.exs
+++ b/test/types/string_test.exs
@@ -1,0 +1,14 @@
+defmodule Dry.Types.StringTest do
+  use ExSpec
+
+  alias Dry.Types
+
+  describe "#options" do
+    it "returns the correct struct" do
+      assert Types.String.options(default: "str", optional: true) == %Types.String{optional: true, default: "str"}
+      assert Types.String.options(default: "str") == %Types.String{default: "str"}
+      assert Types.String.options(invalid: "str") == %Types.String{}
+      assert Types.String.options() == %Types.String{}
+    end
+  end
+end


### PR DESCRIPTION
Instead of relying on atoms to describe the type and the various options, Dry.Types have been implemented